### PR TITLE
discontinue use of the cloudflare-sg module in terraform-modules repo

### DIFF
--- a/cloudflare-ips.sh
+++ b/cloudflare-ips.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# NOTE: this didn't work without jq because the external data source expects the result to be a map
+# with string keys and string values. The API response is more complex.
+
+set -e
+
+curl --silent --fail 'https://api.cloudflare.com/client/v4/ips' | jq '{
+  ipv4_cidrs: (.result.ipv4_cidrs | join(",")),
+  ipv6_cidrs: (.result.ipv6_cidrs | join(","))
+}'

--- a/versions.tf
+++ b/versions.tf
@@ -13,6 +13,10 @@ terraform {
       // While waiting for version 5 to mature, we'll constrain to earlier versions.
       version = ">= 2.0.0, < 4.39.0"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.0"
+    }
     random = {
       version = "~> 3.0"
       source  = "hashicorp/random"

--- a/vpc.tf
+++ b/vpc.tf
@@ -15,9 +15,46 @@ module "vpc" {
 /*
  * Security group to limit traffic to Cloudflare IPs
  */
-module "cloudflare-sg" {
-  source = "github.com/sil-org/terraform-modules//aws/cloudflare-sg?ref=8.13.3"
-  vpc_id = module.vpc.id
+
+resource "aws_security_group" "cloudflare" {
+  name        = "cloudflare-https"
+  description = "Allow HTTPS traffic from Cloudflare"
+  vpc_id      = module.vpc.id
+  tags = {
+    Name = "${local.app_name_and_env}-cloudflare"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  timeouts {
+    delete = "2m"
+  }
+}
+
+resource "aws_security_group_rule" "cloudflare" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.cloudflare.id
+  cidr_blocks       = split(",", data.external.cloudflare_ips.result.ipv4_cidrs)
+  ipv6_cidr_blocks  = split(",", data.external.cloudflare_ips.result.ipv6_cidrs)
+}
+
+data "external" "cloudflare_ips" {
+  program = ["${path.module}/cloudflare-ips.sh"]
+}
+
+moved {
+  from = module.cloudflare-sg.aws_security_group.cloudflare_https
+  to   = aws_security_group.cloudflare
+}
+
+moved {
+  from = module.cloudflare-sg.aws_security_group_rule.cloudflare
+  to   = aws_security_group_rule.cloudflare
 }
 
 /*
@@ -103,7 +140,7 @@ module "alb" {
   vpc_id              = module.vpc.id
   security_groups = [
     module.vpc.vpc_default_sg_id,
-    var.use_cloudflare_sg ? module.cloudflare-sg.id : one(aws_security_group.public_https[*].id)
+    var.use_cloudflare_sg ? aws_security_group.cloudflare.id : one(aws_security_group.public_https[*].id)
   ]
   subnets         = module.vpc.public_subnet_ids
   certificate_arn = data.aws_acm_certificate.default.arn


### PR DESCRIPTION
[ITSE-1581](https://support.gtis.sil.org/issue/ITSE-1581) terraform-modules #116: silent failure in cloudflare-sg module

---

### Changed
- Replace the cloudflare-sg module in the now-archived terraform-modules repo. Instead, use curl to fetch the IP list from Cloudflare. This has more robust error handling that the method used in the cloudflare-sg module.