### PR TITLE
add task_role_arn input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -278,6 +278,7 @@ module "ecs" {
   desired_count      = var.desired_count
   ecsServiceRole_arn = module.ecsasg.ecsServiceRole_arn
   execution_role_arn = var.execution_role_arn
+  task_role_arn      = var.task_role_arn
 
   load_balancer = [{
     container_name   = "hub"

--- a/test/test.tf
+++ b/test/test.tf
@@ -32,6 +32,10 @@ module "full" {
   instance_type            = "t3.micro"
   create_adminer           = true
   enable_adminer           = true
+  log_retention_in_days    = 60
+  task_role_arn            = "arn:aws:iam::111111111111:role/task-role"
+  execution_role_arn       = "arn:aws:iam::111111111111:role/exec-role"
+
   health_check = {
     enabled             = true
     healthy_threshold   = 3
@@ -43,7 +47,7 @@ module "full" {
     timeout             = 10
     unhealthy_threshold = 3
   }
-  log_retention_in_days = 60
+
   asg_tags = {
     foo = "bar",
   }

--- a/variables.tf
+++ b/variables.tf
@@ -320,5 +320,11 @@ variable "execution_role_arn" {
     using Fargate or to reference secrets from SSM Parameter Store.
     EOF
   type        = string
-  default     = ""
+  default     = null
+}
+
+variable "task_role_arn" {
+  description = "ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services."
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
[IDP-1820](https://support.gtis.sil.org/issue/IDP-1820) Add support for IAM Role to ssp-base for DynamoDB

---

### Added
- Added a new input `task_role_arn` to specify the task role in the service's task definition.

### Fixed
- Corrected the default value of `execution_role_arn` to `null`. This explicitly specifies that no execution role is to be applied to the task definition. The AWS provider seems to handle the previous default (empty string) gracefully, but `null` is more correct.