### PR TITLE
add the task role to the CD PassRole policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,7 @@ data "aws_iam_policy_document" "cd" {
     resources = compact([
       module.ecsasg.ecsServiceRole_arn,
       var.execution_role_arn,
+      var.task_role_arn
     ])
   }
 }


### PR DESCRIPTION
### Fixed

- Add the task role to the CD PassRole policy to fix deployment error: "Error: aws: [ERROR]: An error occurred (AccessDeniedException) when calling the RegisterTaskDefinition operation: User: arn:aws:sts::857635630912:assumed-role/cd-idp-hub-prod-us-west-2/GitHubActions is not authorized to perform: iam:PassRole on resource: arn:aws:iam::857635630912:role/ecs-task-idp-hub-prod-us-west-2 because no identity-based policy allows the iam:PassRole action"