### PR TITLE
update Cloudflare provider 

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -7,11 +7,8 @@ terraform {
       version = ">= 4.0.0, < 6.0.0"
     }
     cloudflare = {
-      source = "cloudflare/cloudflare"
-
-      // 4.39.0 deprecated cloudflare_record.value
-      // While waiting for version 5 to mature, we'll constrain to earlier versions.
-      version = ">= 2.0.0, < 4.39.0"
+      source  = "cloudflare/cloudflare"
+      version = ">= 2.0.0, < 5.0.0"
     }
     external = {
       source  = "hashicorp/external"


### PR DESCRIPTION
### Changed
- Updated Cloudflare provider constraint to allow the latest 4.x version in preparation for the upgrade to version 5.