### PR TITLE
upgrade providers (AWS v6, Cloudflare v5)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     uses: sil-org/workflows/.github/workflows/terraform.yml@main
     with:
-      terraform-version: '~> 1.2'
+      terraform-version: '~> 1.8'
       test-dir: test
 
   tftest:
@@ -19,11 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      # Install Terraform 1.7, which is the earliest that supports `terraform test`.
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: "1.7.5"
+          terraform_version: "~> 1.8"
 
       - name: Test
         run: |

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   db_password = random_password.db_root.result
 
   account = data.aws_caller_identity.this.account_id
-  region  = data.aws_region.current.name
+  region  = data.aws_region.current.region
 }
 
 /*
@@ -137,10 +137,10 @@ resource "aws_cloudwatch_log_group" "logs" {
  */
 resource "aws_alb_target_group" "tg" {
   name                 = substr("tg-${local.app_name_and_env}", 0, 32)
-  port                 = "80"
+  port                 = 80
   protocol             = "HTTP"
   vpc_id               = module.vpc.id
-  deregistration_delay = "30"
+  deregistration_delay = 30
 
   stickiness {
     type = "lb_cookie"
@@ -167,7 +167,7 @@ resource "aws_alb_target_group" "tg" {
  */
 resource "aws_alb_listener_rule" "tg" {
   listener_arn = module.alb.https_listener_arn
-  priority     = "218"
+  priority     = 218
 
   action {
     type             = "forward"
@@ -192,7 +192,7 @@ module "ecs-service-cloudwatch-dashboard" {
   count = var.create_dashboard ? 1 : 0
 
   source  = "sil-org/ecs-service-cloudwatch-dashboard/aws"
-  version = "~> 3.1"
+  version = "~> 4.0"
 
   cluster_name   = module.ecsasg.ecs_cluster_name
   dashboard_name = "${local.app_name_and_env}-${local.region}"
@@ -218,7 +218,7 @@ resource "aws_db_instance" "this" {
   allow_major_version_upgrade = var.database_allow_major_version_upgrade
   engine                      = "mariadb"
   engine_version              = var.database_engine_version
-  allocated_storage           = "20" // 20 gibibyte
+  allocated_storage           = 20 // 20 gibibyte
   copy_tags_to_snapshot       = true
   ca_cert_identifier          = var.rds_ca_cert_identifier
   instance_class              = var.database_instance_class
@@ -229,7 +229,7 @@ resource "aws_db_instance" "this" {
   db_subnet_group_name        = module.vpc.db_subnet_group_name
   storage_type                = "gp2"
   storage_encrypted           = var.database_storage_encrypted
-  backup_retention_period     = "14"
+  backup_retention_period     = 14
   multi_az                    = var.database_multi_az
   publicly_accessible         = false
   vpc_security_group_ids      = [module.vpc.vpc_default_sg_id]
@@ -250,7 +250,7 @@ resource "aws_db_instance" "this" {
 module "adminer" {
   count   = var.create_adminer ? 1 : 0
   source  = "sil-org/adminer/aws"
-  version = "~> 1.1"
+  version = "~> 4.0"
 
   adminer_default_server = aws_db_instance.this.address
   app_name               = var.app_name
@@ -270,7 +270,7 @@ module "adminer" {
  */
 module "ecs" {
   source  = "sil-org/ecs-service/aws"
-  version = "~> 0.3.0"
+  version = "~> 1.0"
 
   cluster_id         = module.ecsasg.ecs_cluster_id
   service_name       = var.app_name
@@ -291,19 +291,26 @@ module "ecs" {
 /*
  * Create Cloudflare DNS record
  */
-resource "cloudflare_record" "dns" {
+resource "cloudflare_dns_record" "dns" {
   count = var.create_dns_record ? 1 : 0
 
-  zone_id         = data.cloudflare_zone.this.id
-  name            = var.subdomain
-  value           = module.alb.dns_name
-  type            = "CNAME"
-  proxied         = true
-  allow_overwrite = var.dns_allow_overwrite
+  zone_id = data.cloudflare_zone.this.id
+  name    = var.subdomain
+  content = module.alb.dns_name
+  type    = "CNAME"
+  proxied = true
+  ttl     = 1
+}
+
+moved {
+  from = cloudflare_record.dns
+  to   = cloudflare_dns_record.dns
 }
 
 data "cloudflare_zone" "this" {
-  name = var.domain_name
+  filter = {
+    name = var.domain_name
+  }
 }
 
 

--- a/test/test.tf
+++ b/test/test.tf
@@ -62,14 +62,14 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.8"
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     cloudflare = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "cloudflare/cloudflare"
     }
     random = {

--- a/variables.tf
+++ b/variables.tf
@@ -78,12 +78,6 @@ variable "create_dns_record" {
   type        = bool
 }
 
-variable "dns_allow_overwrite" {
-  description = "Controls whether this module can overwrite an existing DNS record with the same name. Can be used in a multiregion DNS-based failover configuration."
-  type        = bool
-  default     = false
-}
-
 variable "domain_name" {
   description = "The domain name on which to host the app. Combined with \"subdomain\" to create an ALB listener rule. Also used for the optional DNS record."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = "~> 6.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 2.0.0, < 5.0.0"
+      version = "5.22.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/vpc.tf
+++ b/vpc.tf
@@ -4,7 +4,7 @@
  */
 module "vpc" {
   source  = "sil-org/vpc/aws"
-  version = "~> 1.0"
+  version = "~> 1.1"
 
   app_name    = var.app_name
   app_env     = var.app_env
@@ -130,7 +130,7 @@ data "aws_acm_certificate" "default" {
  */
 module "alb" {
   source  = "sil-org/alb/aws"
-  version = "~> 1.1"
+  version = "~> 2.0"
 
   app_name            = var.app_name
   app_env             = var.app_env
@@ -181,7 +181,7 @@ resource "aws_security_group_rule" "public_https" {
  */
 module "ecsasg" {
   source  = "sil-org/ecs-asg/aws"
-  version = "~> 4.1"
+  version = "~> 5.1"
 
   cluster_name                   = local.app_name_and_env
   subnet_ids                     = module.vpc.private_subnet_ids
@@ -191,7 +191,6 @@ module "ecsasg" {
   scaling_metric_name            = "MemoryReservation"
   alarm_actions_enabled          = var.alarm_actions_enabled
   ssh_key_name                   = var.ssh_key_name
-  use_amazon_linux2023           = true
   instance_type                  = var.instance_type
   tags                           = var.asg_tags
   enable_ipv6                    = var.enable_ipv6


### PR DESCRIPTION
[ITSE-2706](https://support.gtis.sil.org/issue/ITSE-2706) Update Terraform AWS provider to 6.x

---

### Changed (BREAKING)
- Require Terraform version 1.8 or later to support the Cloudflare provider upgrade.
- Require AWS provider version 6. The aws_region data source removed `name` in version 6.
- Require Cloudflare provider version 5. The cloudflare_record resource was removed in version 5.
- Removed variable `dns_allow_overwrite` because the underlying property on `cloudflare_dns_record` no longer exists.